### PR TITLE
Remove opentabletdriver, add kde calendar system integration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,7 @@
 
 set -ouex pipefail
 
-RELEASE="$(rpm -E %fedora)"
-
-# prepare to install userspace tablet driver
-# note: the user needs to manually enable the systemctl service according to https://opentabletdriver.net/Wiki/FAQ/Linux#autostart
-wget https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest/download/OpenTabletDriver.rpm -O /tmp/opentabletdriver.rpm
-
 rpm-ostree install \
   acpica-tools \
   kio-fuse \
-  /tmp/opentabletdriver.rpm
+  merkuro kdepim-addons kdepim-runtime # I couldn't get these integrations to work via Flatpak


### PR DESCRIPTION
This PR removes the opentabletdriver package layer (since it's now available [on Flathub](https://flathub.org/apps/net.opentabletdriver.OpenTabletDriver)) and attempts to add KDE system calendar integration.