### PR TITLE
Preserve opentabletdriver udev rules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,12 @@ set -ouex pipefail
 # prepare to install userspace tablet driver (this works, and I couldn't get the Flatpak to work standalone)
 # note: the user needs to manually enable the systemctl service according to https://opentabletdriver.net/Wiki/FAQ/Linux#autostart
 wget https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest/download/OpenTabletDriver.rpm -O /tmp/opentabletdriver.rpm
+for c in /etc/udev/rules.d/9{0,9}-opentabletdriver.rules; do
+  if [ -f "${c}" ]; then
+    echo "Copying ${c} into /usr"
+    cp "$c" "/usr/${c}"
+  fi
+done
 
 rpm-ostree install \
   acpica-tools \

--- a/build.sh
+++ b/build.sh
@@ -5,18 +5,21 @@ set -ouex pipefail
 # prepare to install userspace tablet driver (this works, and I couldn't get the Flatpak to work standalone)
 # note: the user needs to manually enable the systemctl service according to https://opentabletdriver.net/Wiki/FAQ/Linux#autostart
 wget https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest/download/OpenTabletDriver.rpm -O /tmp/opentabletdriver.rpm
-for c in /etc/udev/rules.d/*-opentabletdriver.rules; do
-  if [ -f "${c}" ]; then
-    echo "Copying ${c} into /usr"
-    cp "$c" "/usr/${c}"
-  fi
-done
 
 rpm-ostree install \
   acpica-tools \
   kio-fuse \
   /tmp/opentabletdriver.rpm \
   merkuro kdepim-addons kdepim-runtime # I couldn't get these integrations to work via Flatpak
+
+# set up udev rules for userspace tablet driver
+ls /etc/udev/rules.d
+for c in /etc/udev/rules.d/*-opentabletdriver.rules; do
+  if [ -f "${c}" ]; then
+    echo "Copying ${c} into /usr"
+    cp "$c" "/usr/${c}"
+  fi
+done
 
 # install zerotier
 /tmp/install-zerotier.sh

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,8 @@ set -ouex pipefail
 # note: the user needs to manually enable the systemctl service according to https://opentabletdriver.net/Wiki/FAQ/Linux#autostart
 wget https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest/download/OpenTabletDriver.rpm -O /tmp/opentabletdriver.rpm
 for c in /etc/udev/rules.d/9{0,9}-opentabletdriver.rules; do
-  if [ -f "${c}" ]; then
-    echo "Copying ${c} into /usr"
-    cp "$c" "/usr/${c}"
-  fi
+  echo "Copying ${c} into /usr"
+  cp "$c" "/usr/${c}"
 done
 
 rpm-ostree install \

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,11 @@ set -ouex pipefail
 # prepare to install userspace tablet driver (this works, and I couldn't get the Flatpak to work standalone)
 # note: the user needs to manually enable the systemctl service according to https://opentabletdriver.net/Wiki/FAQ/Linux#autostart
 wget https://github.com/OpenTabletDriver/OpenTabletDriver/releases/latest/download/OpenTabletDriver.rpm -O /tmp/opentabletdriver.rpm
-for c in /etc/udev/rules.d/9{0,9}-opentabletdriver.rules; do
-  echo "Copying ${c} into /usr"
-  cp "$c" "/usr/${c}"
+for c in /etc/udev/rules.d/*-opentabletdriver.rules; do
+  if [ -f "${c}" ]; then
+    echo "Copying ${c} into /usr"
+    cp "$c" "/usr/${c}"
+  fi
 done
 
 rpm-ostree install \


### PR DESCRIPTION
This PR attempts to prevent the udev rules installed by OpenTabletDriver from being dropped in the container image.