### PR TITLE
Add newer libwacom tablet data file for Huion Kamvas 13 tablet

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,7 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 
 COPY build.sh /tmp/build.sh
 COPY install-zerotier.sh /tmp/install-zerotier.sh
+COPY huion-kamvas-13.tablet /usr/share/libwacom/huion-kamvas-13.tablet
 RUN mkdir -p /var/lib/alternatives && \
     /tmp/build.sh && \
     mv /var/lib/alternatives /staged-alternatives && \

--- a/huion-kamvas-13.tablet
+++ b/huion-kamvas-13.tablet
@@ -1,0 +1,44 @@
+# Huion
+# Kamvas 13
+# GS1331
+#
+# sysinfo.Xzxg7g1kCc
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/247#issuecomment-1336314324
+#
+# Button Map:
+# (A=1, B=2, C=3, ...)
+#
+#    *-----------------------*
+#    |                       |
+#  A |                       |
+#  B |                       |
+#  C |                       |
+#  D |                       |
+#  E |        TABLET         |
+#  F |                       |
+#  G |                       |
+#  H |                       |
+#    |                       |
+#    *-----------------------*
+#
+[Device]
+Name=Huion Kamvas 13
+ModelName=GS1331
+DeviceMatch=usb|256c|006d|HUION Huion Tablet_GS1331 Pad;usb|256c|006d|HUION Huion Tablet_GS1331 Pen;usb|256c|006d|Tablet Monitor;usb|256c|006d|Tablet Monitor Pad;usb|256c|006d|Tablet Monitor Pen
+Width=12
+Height=7
+IntegratedIn=Display
+Layout=huion-kamvas-13.svg
+Styli=@generic-no-eraser
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=false
+TouchSwitch=false
+NumRings=0
+NumStrips=0
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7


### PR DESCRIPTION
This PR attempts to add support for my Huion Kamvas 13 tablet in libwacom, by overriding the tablet data file currently installed with the newer one from https://github.com/linuxwacom/libwacom/blob/master/data/huion-kamvas-13.tablet .